### PR TITLE
Discover class attributes by interrogating setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
-dist: xenial
+dist: bionic
 python:
-  - "3.5"
+  - "3.6"
+  - "3.8"
 
 # command to install testing dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: bionic
 python:
-  - "3.6"
   - "3.8"
 
 # command to install testing dependencies

--- a/chrisapp/base.py
+++ b/chrisapp/base.py
@@ -18,7 +18,7 @@
  *
  *                       U  L  T  R  O  N
  *
- * (c) 2016 Fetal-Neonatal Neuroimaging & Developmental Science Center
+ * (c) 2016-2020 Fetal-Neonatal Neuroimaging & Developmental Science Center
  *                   Boston Children's Hospital
  *
  *              http://childrenshospital.org/FNNDSC/
@@ -27,10 +27,10 @@
  */
 """
 import os
-from argparse import Action
-from argparse import ArgumentParser
-from argparse import ArgumentTypeError
+import sys
+from argparse import Action, ArgumentParser, ArgumentTypeError
 import json
+import importlib.metadata
 
 
 class NoArgAction(Action):
@@ -97,21 +97,79 @@ class BaseClassAttrEnforcer(type):
     Meta class to enforce class variables in subclasses.
     """
     def __init__(cls, name, bases, d):
+        if 'PACKAGE' in d:
+            # interrogate setup.py to automatically fill in some class attributes for the subclass
+            autofill = ['AUTHORS', 'TITLE', 'DESCRIPTION', 'LICENSE', 'DOCUMENTATION', 'VERSION']
+            for attr in autofill:
+                if attr in d:
+                    raise ValueError('Do not manually set value value for '
+                                     f'"{attr}" when "PACKAGE={d["PACKAGE"]}" is declared')
+            pkg = importlib.metadata.Distribution.from_name(d['PACKAGE'])
+            setup = pkg.metadata
+            cls.AUTHORS = f'{setup["author"]} <{setup["author-email"]}>'
+            d['AUTHORS'] = cls.AUTHORS
+            cls.TITLE = setup['name']
+            d['TITLE'] = cls.TITLE
+            cls.DESCRIPTION = setup['summary']
+            d['DESCRIPTION'] = cls.DESCRIPTION
+            cls.LICENSE = setup['license']
+            d['LICENSE'] = cls.LICENSE
+            cls.DOCUMENTATION = setup['home-page']
+            d['DOCUMENTATION'] = cls.DOCUMENTATION
+            cls.VERSION = setup['version']
+            d['VERSION'] = cls.VERSION
+
+            if 'SELFEXEC' not in d:
+                eps = [ep for ep in pkg.entry_points if ep.group == 'console_scripts']
+                if eps:
+                    if len(eps) > 1:
+                        # multiple console_scripts found but maybe they're just the same thing
+                        different_scripts = [ep for ep in eps if ep.value != eps[0].value]
+                        if different_scripts:
+                            raise ValueError('SELFEXEC not defined and more than one console_scripts found')
+                    cls.SELFEXEC = eps[0].name
+                    d['SELFEXEC'] = cls.SELFEXEC
+                    cls.EXECSHELL = sys.executable
+                    d['EXECSHELL'] = cls.EXECSHELL
+                    # when pip is used to install a script on the metal, it is put in /usr/local/bin
+                    # but if we're in a virtualenv, try to detect that
+                    cls.SELFPATH = os.path.join(os.getenv('VIRTUAL_ENV'), 'bin') \
+                        if 'VIRTUAL_ENV' in os.environ else '/usr/local/bin'
+                    d['SELFPATH'] = cls.SELFPATH
+
+
         # class variables to be enforced in the subclasses
         attrs = ['DESCRIPTION', 'TYPE', 'TITLE', 'LICENSE', 'SELFPATH', 'SELFEXEC',
                  'EXECSHELL', 'OUTPUT_META_DICT', 'AUTHORS', 'VERSION']
         for attr in attrs:
             if attr not in d:
-                raise ValueError("Class %s doesn't define %s class variable" % (name,
-                                                                                attr))
+                raise ValueError(f"Class {name} doesn't define {attr} class variable")
         type.__init__(cls, name, bases, d)
 
 
 class ChrisApp(ArgumentParser, metaclass=BaseClassAttrEnforcer):
     """
-    The super class for all valid ChRIS plugin apps.
-    """
+    The superclass for all ChRIS plugin apps.
 
+    Meta-information about the subclass must be given as class attributes.
+    This is enforced by a metaclass.
+
+    Subclasses should manually define
+
+        AUTHORS, TITLE, DESCRIPTION, LICENSE, DOCUMENTATION, VERSION,
+        SELFPATH, SELFEXEC, EXECSHELL
+
+    Or, the metaclass can interrogate setup.py to discover the information
+    automatically. Enable this feature by setting
+
+        PACKAGE = __package__
+
+    The following class variables *must* be supplied, as they cannot
+    be discovered from setup.py
+
+        TYPE, OUTPUT_META_DICT
+
+    """
     AUTHORS = 'FNNDSC (dev@babyMRI.org)'
     TITLE = ''
     CATEGORY = ''
@@ -124,14 +182,22 @@ class ChrisApp(ArgumentParser, metaclass=BaseClassAttrEnforcer):
     DOCUMENTATION = ''
     LICENSE = ''
     VERSION = ''
-    MAX_NUMBER_OF_WORKERS = 1  # Override with integer value
-    MIN_NUMBER_OF_WORKERS = 1  # Override with integer value
-    MAX_CPU_LIMIT = ''         # Override with millicore value as string, e.g. '2000m'
-    MIN_CPU_LIMIT = ''         # Override with millicore value as string, e.g. '2000m'
-    MAX_MEMORY_LIMIT = ''      # Override with string, e.g. '1Gi', '2000Mi'
-    MIN_MEMORY_LIMIT = ''      # Override with string, e.g. '1Gi', '2000Mi'
-    MIN_GPU_LIMIT = 0          # Override with the minimum number of GPUs, as an integer, for your plugin
-    MAX_GPU_LIMIT = 0          # Override with the maximum number of GPUs, as an integer, for your plugin
+    MAX_NUMBER_OF_WORKERS = 1
+    """Integer value"""
+    MIN_NUMBER_OF_WORKERS = 1
+    """Integer value"""
+    MAX_CPU_LIMIT = ''
+    """millicore value as string, e.g. '2000m'"""
+    MIN_CPU_LIMIT = ''
+    """millicore value as string, e.g. '2000m'"""
+    MAX_MEMORY_LIMIT = ''
+    """string, e.g. '1Gi', '2000Mi'"""
+    MIN_MEMORY_LIMIT = ''
+    """string, e.g. '1Gi', '2000Mi'"""
+    MIN_GPU_LIMIT = 0
+    """number of GPUs"""
+    MAX_GPU_LIMIT = 0
+    """number of GPUs"""
 
     OUTPUT_META_DICT = {}
 

--- a/chrisapp/tests/test_base.py
+++ b/chrisapp/tests/test_base.py
@@ -1,4 +1,5 @@
 
+import sys
 import os
 import shutil
 import json
@@ -215,3 +216,30 @@ class ChrisAppTests(unittest.TestCase):
         self.app.save_output_meta()
         output_meta_dict = self.app.load_output_meta()
         self.assertEqual(output_meta_dict, self.app.OUTPUT_META_DICT)
+
+    def test_interrogate_setup(self):
+
+        class NoseFakePlugin(ChrisApp):
+            PACKAGE = 'nose'
+            TYPE = 'FS',
+            OUTPUT_META_DICT = {}
+
+            def show_man_page(self):
+                print('man')
+
+            def define_parameters(self):
+                pass
+
+            def run(self, options):
+                print('run')
+
+        self.assertEqual(NoseFakePlugin.AUTHORS, 'Jason Pellerin <jpellerin+nose@gmail.com>')
+        self.assertEqual(NoseFakePlugin.TITLE, 'nose')
+        self.assertEqual(NoseFakePlugin.DESCRIPTION, 'nose extends unittest to make testing easier')
+        self.assertEqual(NoseFakePlugin.DOCUMENTATION, 'http://readthedocs.org/docs/nose/')
+        self.assertEqual(NoseFakePlugin.VERSION, '1.3.7')
+        self.assertEqual(
+            NoseFakePlugin.SELFPATH,
+            os.path.join(os.getenv('VIRTUAL_ENV'), 'bin') if 'VIRTUAL_ENV' in os.environ else '/usr/local/bin')
+        self.assertEqual(NoseFakePlugin.SELFEXEC, 'nosetests')
+        self.assertEqual(NoseFakePlugin.EXECSHELL, sys.executable)

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     tests_require    = ['nose==1.3.7'],
     license          = 'MIT',
     zip_safe         = False,
-    python_requires='>=3.5'
+    python_requires = '>=3.7'
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
       packages         =   ['chrisapp'],
       #install_requires =   [],
       test_suite       =   'nose.collector',
-      tests_require    =   ['nose'],
+      tests_require    =   ['nose==1.3.7'],
       #scripts          =   [],
       license          =   'MIT',
       zip_safe=False


### PR DESCRIPTION
# Features

- docstring under class attributes improves IDE support
- metaclass can interrogate a package's metadata to automatically discover ChRIS plugin information, designating `setup.py` as a single-source "ground-truth" for ChRIS plugin information
- add test for the feature

# Before merge

- [x] merge #9 
- [x] bump version to `1.2.0`
