### PR TITLE
Enforce class attrs are str

### DIFF
--- a/chrisapp/base.py
+++ b/chrisapp/base.py
@@ -104,6 +104,7 @@ class BaseClassAttrEnforcer(type):
                 if attr in d:
                     raise ValueError('Do not manually set value value for '
                                      f'"{attr}" when "PACKAGE={d["PACKAGE"]}" is declared')
+
             pkg = importlib.metadata.Distribution.from_name(d['PACKAGE'])
             setup = pkg.metadata
             cls.AUTHORS = f'{setup["author"]} <{setup["author-email"]}>'
@@ -137,13 +138,20 @@ class BaseClassAttrEnforcer(type):
                         if 'VIRTUAL_ENV' in os.environ else '/usr/local/bin'
                     d['SELFPATH'] = cls.SELFPATH
 
-
         # class variables to be enforced in the subclasses
-        attrs = ['DESCRIPTION', 'TYPE', 'TITLE', 'LICENSE', 'SELFPATH', 'SELFEXEC',
-                 'EXECSHELL', 'OUTPUT_META_DICT', 'AUTHORS', 'VERSION']
+        attrs = [
+            'DESCRIPTION', 'TYPE', 'TITLE', 'LICENSE', 'AUTHORS', 'VERSION',
+            'SELFPATH', 'SELFEXEC', 'EXECSHELL'
+        ]
         for attr in attrs:
             if attr not in d:
                 raise ValueError(f"Class {name} doesn't define {attr} class variable")
+            if type(d[attr]) is not str:
+                raise ValueError(f'{attr} ({type(attr)}) must be a string')
+        if 'OUTPUT_META_DICT' not in d:
+            raise ValueError(f"Class {name} doesn't define OUTPUT_META_DICT")
+        if type(d['OUTPUT_META_DICT']) is not dict:
+            raise ValueError('OUTPUT_META_DICT must be dict')
         type.__init__(cls, name, bases, d)
 
 

--- a/chrisapp/tests/test_base.py
+++ b/chrisapp/tests/test_base.py
@@ -217,11 +217,32 @@ class ChrisAppTests(unittest.TestCase):
         output_meta_dict = self.app.load_output_meta()
         self.assertEqual(output_meta_dict, self.app.OUTPUT_META_DICT)
 
-    def test_interrogate_setup(self):
+    def test_enforce_attr_string(self):
+        with self.assertRaisesRegex(ValueError, 'must be a string') as cm:
+            class VersionIsFloat(ChrisApp):
+                DESCRIPTION = 'should not work'
+                TYPE = 'DS'
+                TITLE = 'broken'
+                LICENSE = 'MIT'
+                SELFPATH = '/usr/local/bin'
+                SELFEXEC = 'wow'
+                EXECSHELL = 'python'
+                AUTHORS = 'me'
+                VERSION = 1.2  # wrong, should be a str
 
+                def show_man_page(self):
+                    print('man')
+
+                def define_parameters(self):
+                    pass
+
+                def run(self, options):
+                    print('run')
+
+    def test_interrogate_setup(self):
         class NoseFakePlugin(ChrisApp):
             PACKAGE = 'nose'
-            TYPE = 'FS',
+            TYPE = 'FS'
             OUTPUT_META_DICT = {}
 
             def show_man_page(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(path.join(path.dirname(path.abspath(__file__)), 'README.rst')) as f:
 
 setup(
     name             = 'chrisapp',
-    version          = '2.0.0',
+    version          = '2.0.1',
     description      = 'Superclass for Chris plugin apps',
     long_description = readme,
     author           = 'FNNDSC',


### PR DESCRIPTION
Static analysis fix for https://github.com/FNNDSC/ChRIS_store/issues/31

- enforce class attrs are `str`
- add tests
- bump patch version `2.0.0` -> `2.0.1`