### PR TITLE
Support outdated python version 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,18 @@ on:
 jobs:
   local:
     name: Nose tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.8', '3.x' ]
     steps:
       - uses: actions/checkout@v2
-      - name: install nose
-        run: |
-          pip install nose
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install .
+      - run: pip install nose
       - run: nosetests
   integration:
     name: Integration tests
@@ -65,6 +70,6 @@ jobs:
           CMD ["{{ cookiecutter.app_name }}", "--help"]
           EOF
       - name: setup CUBE
-        uses: fnndsc/minimake@v1
+        uses: fnndsc/minimake@v2
       - name: Run example
         run: ./cookiecutter-chrisapp/example.sh cookiecutter-chrisapp

--- a/chrisapp/base.py
+++ b/chrisapp/base.py
@@ -31,8 +31,13 @@ import sys
 import shutil
 from argparse import Action, ArgumentParser, ArgumentTypeError
 import json
-import importlib.metadata
 
+try:
+    # since python>=3.8, importlib.metadata is part of the standard library
+    from importlib.metadata import Distribution
+except ModuleNotFoundError:
+    # for python<=3.7, a backport is used
+    from importlib_metadata import Distribution
 
 class NoArgAction(Action):
     """
@@ -108,7 +113,7 @@ class BaseClassAttrEnforcer(type):
                         'Do not manually set value value for '
                         f'"{attr}" when "PACKAGE={d["PACKAGE"]}" is declared')
 
-            pkg = importlib.metadata.Distribution.from_name(d['PACKAGE'])
+            pkg = Distribution.from_name(d['PACKAGE'])
             setup = pkg.metadata
             if 'TITLE' not in d:
                 cls.TITLE = setup['name']

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,19 @@ with open(path.join(path.dirname(path.abspath(__file__)), 'README.rst')) as f:
 
 setup(
     name             = 'chrisapp',
-    version          = '2.3.0-1',
+    version          = '2.4.0',
     description      = 'Superclass for Chris plugin apps',
     long_description = readme,
     author           = 'FNNDSC',
     author_email     = 'dev@babymri.org',
     url              = 'https://github.com/FNNDSC/chrisapp',
     packages         = ['chrisapp'],
+    install_requires = [
+        'importlib-metadata; python_version<"3.7"'
+    ],
     test_suite       = 'nose.collector',
     tests_require    = ['nose==1.3.7'],
     license          = 'MIT',
     zip_safe         = False,
-    python_requires = '>=3.7'
+    python_requires = '>=3.6'
 )


### PR DESCRIPTION
Enables `chrisapp~=2.4.0` to be used with tensorflow images such as
https://hub.docker.com/repository/docker/fnndsc/tensorflow/general